### PR TITLE
feat: Introduce `Evaluator` function for LLM scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ With a **unified API** and **builder style** - similar to the Stripe experience 
 - **Extensible**: Easily add new backends.
 - **Rust-friendly**: Designed with clear traits, unified error handling, and conditional compilation via *features*.
 - **Validation**: Add validation to your requests to ensure the output is what you expect.
+- **Evaluation**: Add evaluation to your requests to score the output of LLMs.
 
 ## Installation
 
@@ -37,6 +38,7 @@ rllm = { version = "1.0.0", features = ["openai", "anthropic", "ollama"] }
 | [`phind_example`](examples/phind_example.rs) | Basic Phind chat completion example with Phind-70B model |
 | [`validator_example`](examples/validator_example.rs) | Basic validator example with Anthropic's Claude model |
 | [`xai_example`](examples/xai_example.rs) | Basic xAI chat completion example with Grok models |
+| [`evaluation_example`](examples/evaluation_example.rs) | Basic evaluation example with Anthropic, Phind and DeepSeek |
 
 ## Usage
 Here's a basic example using OpenAI for chat completion. See the examples directory for other backends (Anthropic, Ollama, DeepSeek, xAI), embedding capabilities, and more advanced use cases.

--- a/examples/evaluation_example.rs
+++ b/examples/evaluation_example.rs
@@ -1,0 +1,85 @@
+// Import required modules from RLLM and serde_json
+use rllm::{
+    builder::{LLMBackend, LLMBuilder},
+    chat::{ChatMessage, ChatRole}, 
+    evaluator::{EvalResult, LLMEvaluator},
+};
+use serde_json::Value;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize OpenAI LLM with API key from environment or fallback
+    let openai = LLMBuilder::new()
+        .backend(LLMBackend::OpenAI)
+        .model("gpt-3.5-turbo")
+        .api_key(std::env::var("OPENAI_API_KEY").unwrap_or("sk-OPENAI".into()))
+        .build()?;
+
+    // Initialize Anthropic LLM with API key from environment or fallback
+    let anthropic = LLMBuilder::new()
+        .backend(LLMBackend::Anthropic)
+        .model("claude-3-5-sonnet-20240620")
+        .api_key(std::env::var("ANTHROPIC_API_KEY").unwrap_or("anthropic-key".into()))
+        .build()?;
+
+    // Initialize Phind LLM (no API key required)
+    let phind = LLMBuilder::new()
+        .backend(LLMBackend::Phind)
+        .model("Phind-70B")
+        .build()?;
+
+    // Initialize DeepSeek LLM with API key from environment or fallback
+    let deepseek = LLMBuilder::new()
+        .backend(LLMBackend::DeepSeek)
+        .model("deepseek-chat")
+        .api_key(std::env::var("DEEPSEEK_API_KEY").unwrap_or("deepseek-key".into()))
+        .build()?;
+
+    // Create evaluator with all LLM providers and custom scoring function
+    let evaluator = LLMEvaluator::new(vec![openai, anthropic, phind, deepseek])
+        .scoring(|resp_text| {
+            // Try to parse response as JSON
+            let json_result = serde_json::from_str::<Value>(resp_text);
+            
+            match json_result {
+                Ok(json) => {
+                    let mut total_score = 0.0;
+                    
+                    // Score based on greeting field content
+                    if let Some(greeting) = json.get("greeting") {
+                        if let Some(text) = greeting.as_str() {
+                            let text_lower = text.to_lowercase();
+                            // Base point for having greeting field
+                            total_score += 1.0;
+                            // Points for each "yes" occurrence
+                            total_score += text_lower.matches("yes").count() as f32;
+                            // Bonus point for common greeting words
+                            if text_lower.contains("hello") || text_lower.contains("hi") || text_lower.contains("hey") {
+                                total_score += 1.0;
+                            }
+                        }
+                    }
+                    
+                    total_score
+                },
+                Err(_) => 0.0 // Zero score for invalid JSON
+            }
+        });
+
+    // Prepare chat message requesting JSON greeting
+    let messages = vec![ChatMessage {
+        role: ChatRole::User,
+        content: "Give me a short greeting with only the word 'yes' in it! in json format with this format : {greeting: 'yes'}. only JSON.".into(),
+    }];
+
+    // Evaluate responses from all LLMs
+    let results: Vec<EvalResult> = evaluator.evaluate_chat(&messages)?;
+    // Print results with scores
+    for (i, item) in results.iter().enumerate() {
+        println!(
+            "LLM #{} => Score={:.2}, text:\n{}",
+            i, item.score, item.text
+        );
+    }
+
+    Ok(())
+}

--- a/examples/evaluation_example.rs
+++ b/examples/evaluation_example.rs
@@ -1,84 +1,115 @@
-// Import required modules from RLLM and serde_json
+//! Example demonstrating evaluation and comparison of multiple LLM providers
+//!
+//! This example shows how to:
+//! 1. Initialize multiple LLM providers (Anthropic, Phind, DeepSeek)
+//! 2. Configure scoring functions to evaluate responses
+//! 3. Send the same prompt to all providers
+//! 4. Compare and score the responses
+
 use rllm::{
     builder::{LLMBackend, LLMBuilder},
-    chat::{ChatMessage, ChatRole}, 
+    chat::{ChatMessage, ChatRole},
     evaluator::{EvalResult, LLMEvaluator},
 };
-use serde_json::Value;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize OpenAI LLM with API key from environment or fallback
-    let openai = LLMBuilder::new()
-        .backend(LLMBackend::OpenAI)
-        .model("gpt-3.5-turbo")
-        .api_key(std::env::var("OPENAI_API_KEY").unwrap_or("sk-OPENAI".into()))
-        .build()?;
-
-    // Initialize Anthropic LLM with API key from environment or fallback
+    // Initialize Anthropic provider with Claude model
     let anthropic = LLMBuilder::new()
         .backend(LLMBackend::Anthropic)
         .model("claude-3-5-sonnet-20240620")
         .api_key(std::env::var("ANTHROPIC_API_KEY").unwrap_or("anthropic-key".into()))
         .build()?;
 
-    // Initialize Phind LLM (no API key required)
+    // Initialize Phind provider specialized for code
     let phind = LLMBuilder::new()
         .backend(LLMBackend::Phind)
         .model("Phind-70B")
         .build()?;
 
-    // Initialize DeepSeek LLM with API key from environment or fallback
+    // Initialize DeepSeek provider
     let deepseek = LLMBuilder::new()
         .backend(LLMBackend::DeepSeek)
         .model("deepseek-chat")
         .api_key(std::env::var("DEEPSEEK_API_KEY").unwrap_or("deepseek-key".into()))
         .build()?;
 
-    // Create evaluator with all LLM providers and custom scoring function
-    let evaluator = LLMEvaluator::new(vec![openai, anthropic, phind, deepseek])
-        .scoring(|resp_text| {
-            // Try to parse response as JSON
-            let json_result = serde_json::from_str::<Value>(resp_text);
-            
-            match json_result {
-                Ok(json) => {
-                    let mut total_score = 0.0;
-                    
-                    // Score based on greeting field content
-                    if let Some(greeting) = json.get("greeting") {
-                        if let Some(text) = greeting.as_str() {
-                            let text_lower = text.to_lowercase();
-                            // Base point for having greeting field
-                            total_score += 1.0;
-                            // Points for each "yes" occurrence
-                            total_score += text_lower.matches("yes").count() as f32;
-                            // Bonus point for common greeting words
-                            if text_lower.contains("hello") || text_lower.contains("hi") || text_lower.contains("hey") {
-                                total_score += 1.0;
-                            }
-                        }
-                    }
-                    
-                    total_score
-                },
-                Err(_) => 0.0 // Zero score for invalid JSON
+    // Create evaluator with multiple scoring functions
+    let evaluator = LLMEvaluator::new(vec![anthropic, phind, deepseek])
+        // First scoring function: Evaluate code quality and completeness
+        .scoring(|response| {
+            let mut score = 0.0;
+
+            // Check for code blocks and specific Rust features
+            if response.contains("```") {
+                score += 1.0;
+
+                if response.contains("```rust") {
+                    score += 2.0;
+                }
+
+                if response.contains("use actix_web::") {
+                    score += 2.0;
+                }
+                if response.contains("async fn") {
+                    score += 1.0;
+                }
+                if response.contains("#[derive(") {
+                    score += 1.0;
+                }
+                if response.contains("//") {
+                    score += 1.0;
+                }
             }
+
+            score
+        })
+        // Second scoring function: Evaluate explanation quality
+        .scoring(|response| {
+            let mut score = 0.0;
+
+            // Check for explanatory phrases
+            if response.contains("Here's how it works:") || response.contains("Let me explain:") {
+                score += 2.0;
+            }
+
+            // Check for examples and practical usage
+            if response.contains("For example") || response.contains("curl") {
+                score += 1.5;
+            }
+
+            // Reward comprehensive responses
+            let words = response.split_whitespace().count();
+            if words > 100 {
+                score += 1.0;
+            }
+
+            score
         });
 
-    // Prepare chat message requesting JSON greeting
+    // Define the evaluation prompt requesting a Rust microservice implementation
     let messages = vec![ChatMessage {
         role: ChatRole::User,
-        content: "Give me a short greeting with only the word 'yes' in it! in json format with this format : {greeting: 'yes'}. only JSON.".into(),
+        content: "\
+            Create a Rust microservice using Actix Web. 
+            It should have at least two routes:
+            1) A GET route returning a simple JSON status.
+            2) A POST route that accepts JSON data and responds with a success message.\n\
+            Include async usage, data structures with `#[derive(Serialize, Deserialize)]`, \
+            and show how to run it.\n\
+            Provide code blocks, comments, and a brief explanation of how it works.\
+        "
+        .into(),
     }];
 
-    // Evaluate responses from all LLMs
+    // Run evaluation across all providers
     let results: Vec<EvalResult> = evaluator.evaluate_chat(&messages)?;
-    // Print results with scores
+
+    // Display results with scores
     for (i, item) in results.iter().enumerate() {
-        println!(
-            "LLM #{} => Score={:.2}, text:\n{}",
-            i, item.score, item.text
-        );
+        println!("\n=== LLM #{} ===", i);
+        println!("Score: {:.2}", item.score);
+        println!("Response:\n{}", item.text);
+        println!("================\n");
     }
 
     Ok(())

--- a/examples/validator_example.rs
+++ b/examples/validator_example.rs
@@ -10,18 +10,19 @@ fn main() {
 
     // Initialize and configure the LLM client with validation
     let llm = LLMBuilder::new()
-        .backend(LLMBackend::Anthropic)        // Use Anthropic's Claude model
-        .model("claude-3-5-sonnet-20240620")   // Specify model version
-        .api_key(api_key)                      // Set API credentials
-        .max_tokens(512)                       // Limit response length
-        .temperature(0.7)                      // Control response randomness
-        .stream(false)                         // Disable streaming responses
-        .validator(|resp| {                    // Add JSON validation
+        .backend(LLMBackend::Anthropic) // Use Anthropic's Claude model
+        .model("claude-3-5-sonnet-20240620") // Specify model version
+        .api_key(api_key) // Set API credentials
+        .max_tokens(512) // Limit response length
+        .temperature(0.7) // Control response randomness
+        .stream(false) // Disable streaming responses
+        .validator(|resp| {
+            // Add JSON validation
             serde_json::from_str::<serde_json::Value>(resp)
                 .map(|_| ())
                 .map_err(|e| e.to_string())
         })
-        .validator_attempts(3)                 // Allow up to 3 retries on validation failure
+        .validator_attempts(3) // Allow up to 3 retries on validation failure
         .build()
         .expect("Failed to build LLM (Phind)");
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -192,7 +192,9 @@ impl LLMBuilder {
         let provider: Box<dyn LLMProvider> = match backend {
             LLMBackend::OpenAI => {
                 #[cfg(not(feature = "openai"))]
-                return Err(RllmError::InvalidRequest("OpenAI feature not enabled".to_string()));
+                return Err(RllmError::InvalidRequest(
+                    "OpenAI feature not enabled".to_string(),
+                ));
 
                 #[cfg(feature = "openai")]
                 {
@@ -216,7 +218,9 @@ impl LLMBuilder {
             }
             LLMBackend::Anthropic => {
                 #[cfg(not(feature = "anthropic"))]
-                return Err(RllmError::InvalidRequest("Anthropic feature not enabled".to_string()));
+                return Err(RllmError::InvalidRequest(
+                    "Anthropic feature not enabled".to_string(),
+                ));
 
                 #[cfg(feature = "anthropic")]
                 {
@@ -241,7 +245,9 @@ impl LLMBuilder {
             }
             LLMBackend::Ollama => {
                 #[cfg(not(feature = "ollama"))]
-                return Err(RllmError::InvalidRequest("Ollama feature not enabled".to_string()));
+                return Err(RllmError::InvalidRequest(
+                    "Ollama feature not enabled".to_string(),
+                ));
 
                 #[cfg(feature = "ollama")]
                 {
@@ -266,7 +272,9 @@ impl LLMBuilder {
             }
             LLMBackend::DeepSeek => {
                 #[cfg(not(feature = "deepseek"))]
-                return Err(RllmError::InvalidRequest("DeepSeek feature not enabled".to_string()));
+                return Err(RllmError::InvalidRequest(
+                    "DeepSeek feature not enabled".to_string(),
+                ));
 
                 #[cfg(feature = "deepseek")]
                 {
@@ -289,7 +297,9 @@ impl LLMBuilder {
             }
             LLMBackend::XAI => {
                 #[cfg(not(feature = "xai"))]
-                return Err(RllmError::InvalidRequest("XAI feature not enabled".to_string()));
+                return Err(RllmError::InvalidRequest(
+                    "XAI feature not enabled".to_string(),
+                ));
 
                 #[cfg(feature = "xai")]
                 {
@@ -315,7 +325,9 @@ impl LLMBuilder {
             }
             LLMBackend::Phind => {
                 #[cfg(not(feature = "phind"))]
-                return Err(RllmError::InvalidRequest("Phind feature not enabled".to_string()));
+                return Err(RllmError::InvalidRequest(
+                    "Phind feature not enabled".to_string(),
+                ));
 
                 #[cfg(feature = "phind")]
                 {

--- a/src/evaluator/mod.rs
+++ b/src/evaluator/mod.rs
@@ -1,0 +1,74 @@
+//! Module for evaluating and comparing responses from multiple LLM providers.
+//!
+//! This module provides functionality to run the same prompt through multiple LLMs
+//! and score their responses using custom evaluation functions.
+
+use crate::{chat::ChatMessage, error::RllmError, LLMProvider};
+
+/// Type alias for scoring functions that evaluate LLM responses
+pub type ScoringFn = dyn Fn(&str) -> f32 + Send + Sync + 'static;
+
+/// Evaluator for comparing responses from multiple LLM providers
+pub struct LLMEvaluator {
+    /// Collection of LLM providers to evaluate
+    llms: Vec<Box<dyn LLMProvider>>,
+    /// Optional scoring function to evaluate responses
+    scoring_fn: Option<Box<ScoringFn>>,
+}
+
+impl LLMEvaluator {
+    /// Creates a new evaluator with the given LLM providers
+    ///
+    /// # Arguments
+    /// * `llms` - Vector of LLM providers to evaluate
+    pub fn new(llms: Vec<Box<dyn LLMProvider>>) -> Self {
+        Self {
+            llms,
+            scoring_fn: None,
+        }
+    }
+
+    /// Adds a scoring function to evaluate LLM responses
+    ///
+    /// # Arguments
+    /// * `f` - Function that takes a response string and returns a score
+    pub fn scoring<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&str) -> f32 + Send + Sync + 'static,
+    {
+        self.scoring_fn = Some(Box::new(f));
+        self
+    }
+
+    /// Evaluates chat responses from all providers for the given messages
+    ///
+    /// # Arguments
+    /// * `messages` - Chat messages to send to each provider
+    ///
+    /// # Returns
+    /// Vector of evaluation results containing responses and scores
+    pub fn evaluate_chat(&self, messages: &[ChatMessage]) -> Result<Vec<EvalResult>, RllmError> {
+        let mut results = Vec::new();
+        for llm in &self.llms {
+            let response = llm.chat(messages)?;
+            let score = if let Some(ref func) = self.scoring_fn {
+                (func)(&response)
+            } else {
+                0.0
+            };
+            results.push(EvalResult {
+                text: response,
+                score,
+            });
+        }
+        Ok(results)
+    }
+}
+
+/// Result of evaluating an LLM response
+pub struct EvalResult {
+    /// The text response from the LLM
+    pub text: String,
+    /// Score assigned by the scoring function, if any
+    pub score: f32,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Overview
 //! This crate provides a consistent API for working with different LLM backends by abstracting away
 //! provider-specific implementation details. It supports:
-//! 
+//!
 //! - Chat-based interactions
 //! - Text completion
 //! - Embeddings generation
@@ -36,6 +36,9 @@ pub mod error;
 
 /// Validation wrapper for LLM providers with retry capabilities
 pub mod validated_llm;
+
+/// Evaluator for LLM providers
+pub mod evaluator;
 
 /// Core trait that all LLM providers must implement, combining chat, completion
 /// and embedding capabilities into a unified interface

--- a/src/validated_llm.rs
+++ b/src/validated_llm.rs
@@ -1,5 +1,5 @@
 //! A module providing validation capabilities for LLM responses through a wrapper implementation.
-//! 
+//!
 //! This module enables adding custom validation logic to any LLM provider by wrapping it in a
 //! `ValidatedLLM` struct. The wrapper will validate responses and retry failed attempts with
 //! feedback to help guide the model toward producing valid output.
@@ -8,7 +8,7 @@
 //!
 //! ```no_run
 //! use rllm::{LLMBuilder, LLMBackend};
-//! 
+//!
 //! let llm = LLMBuilder::new()
 //!     .backend(LLMBackend::OpenAI)
 //!     .validator(|response| {


### PR DESCRIPTION
This PR introduces a new `Evaluator` function to **compare and score** the answers returned by one or more LLMs (OpenAI, Anthropic, etc.) **without modifying the existing architecture**.

### Main Changes
- Adds an `Evaluator` structure/function in the evaluation module.
- Allows defining a “scoring function” to assign a score or label to each response.
- Preserves compatibility: *no* changes to the `LLMBuilder` or existing providers.

### Benefits
- Simplifies the simultaneous evaluation of multiple LLMs, akin to a test or benchmark.
- Easily adapts the evaluation logic (criteria, thresholds, etc.).
- Maintains simple and intuitive API.

### Example

```rust
// Initialize OpenAI LLM with API key from environment or fallback
    let openai = LLMBuilder::new()
        .backend(LLMBackend::OpenAI)
        .model("gpt-3.5-turbo")
        .api_key(std::env::var("OPENAI_API_KEY").unwrap_or("sk-OPENAI".into()))
        .build()?;

    // Initialize Anthropic LLM with API key from environment or fallback
    let anthropic = LLMBuilder::new()
        .backend(LLMBackend::Anthropic)
        .model("claude-3-5-sonnet-20240620")
        .api_key(std::env::var("ANTHROPIC_API_KEY").unwrap_or("anthropic-key".into()))
        .build()?;

    // Initialize Phind LLM (no API key required)
    let phind = LLMBuilder::new()
        .backend(LLMBackend::Phind)
        .model("Phind-70B")
        .build()?;

    // Initialize DeepSeek LLM with API key from environment or fallback
    let deepseek = LLMBuilder::new()
        .backend(LLMBackend::DeepSeek)
        .model("deepseek-chat")
        .api_key(std::env::var("DEEPSEEK_API_KEY").unwrap_or("deepseek-key".into()))
        .build()?;

    // Create evaluator with all LLM providers and custom scoring function
    let evaluator = LLMEvaluator::new(vec![openai, anthropic, phind, deepseek])
        .scoring(|resp_text| {
            // Try to parse response as JSON
            let json_result = serde_json::from_str::<Value>(resp_text);
            
            match json_result {
                Ok(json) => {
                    let mut total_score = 0.0;
                    
                    // Score based on greeting field content
                    if let Some(greeting) = json.get("greeting") {
                        if let Some(text) = greeting.as_str() {
                            let text_lower = text.to_lowercase();
                            // Base point for having greeting field
                            total_score += 1.0;
                            // Points for each "yes" occurrence
                            total_score += text_lower.matches("yes").count() as f32;
                            // Bonus point for common greeting words
                            if text_lower.contains("hello") || text_lower.contains("hi") || text_lower.contains("hey") {
                                total_score += 1.0;
                            }
                        }
                    }
                    
                    total_score
                },
                Err(_) => 0.0 // Zero score for invalid JSON
            }
        });

    // Prepare chat message requesting JSON greeting
    let messages = vec![ChatMessage {
        role: ChatRole::User,
        content: "Give me a short greeting with only the word 'yes' in it! in json format with this format : {greeting: 'yes'}. only JSON.".into(),
    }];

    // Evaluate responses from all LLMs
    let results: Vec<EvalResult> = evaluator.evaluate_chat(&messages)?;
    // Print results with scores
    for (i, item) in results.iter().enumerate() {
        println!(
            "LLM #{} => Score={:.2}, text:\n{}",
            i, item.score, item.text
        );
    }
```


### results

```
LLM #0 => Score=2.00, text:
{"greeting": "yes"}
LLM #1 => Score=2.00, text:
{
  "greeting": "yes"
}
LLM #2 => Score=0.00, text:
Here's the JSON object with a greeting containing only the word "yes":
...
```